### PR TITLE
Enable Legacy OpenSSL Provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,15 @@ RUN pip3 install -r requirements.txt
 COPY c3000z_enum.py /app/
 RUN chmod +x c3000z_enum.py
 
+# Copy your provider config file
+COPY providers.cnf /app/
+
+# Insert contents of providers.cnf after [openssl_init] in /etc/ssl/openssl.cnf
+RUN awk '/^\[openssl_init\]/{print; system("cat /app/providers.cnf"); next} 1' \
+    /etc/ssl/openssl.cnf > /etc/ssl/openssl.cnf.new && \
+    mv /etc/ssl/openssl.cnf.new /etc/ssl/openssl.cnf
+
+RUN apt update && apt install -y vim bsdmainutils
+
 CMD ["python3", "./c3000z_enum.py", "--file", "/app/config.xml"]
 

--- a/providers.cnf
+++ b/providers.cnf
@@ -1,0 +1,12 @@
+providers = provider_sect
+
+# List of providers to load
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1


### PR DESCRIPTION
This change just adds the changes to the openssl config file to enable the legacy provider. It now out-of-the box for me with this change.